### PR TITLE
Remove 2nd is_enabled index

### DIFF
--- a/database/migrations/2024_12_25_000000_add_performance_indexes.php
+++ b/database/migrations/2024_12_25_000000_add_performance_indexes.php
@@ -11,20 +11,12 @@ return new class extends Migration
         Schema::table('checks', function (Blueprint $table) {
             $table->index(['monitor_id', 'checked_at', 'response_time'], 'checks_performance_index');
         });
-
-        Schema::table('monitors', function (Blueprint $table) {
-            $table->index('is_enabled');
-        });
     }
 
     public function down(): void
     {
         Schema::table('checks', function (Blueprint $table) {
             $table->dropIndex('checks_performance_index');
-        });
-
-        Schema::table('monitors', function (Blueprint $table) {
-            $table->dropIndex(['is_enabled']);
         });
     }
 };


### PR DESCRIPTION
This is already defined here: https://github.com/janyksteenbeek/uppi/blob/main/database/migrations/2024_12_11_143425_create_monitors_table.php#L24

```
 2024_12_22_183735_add_is_admin_to_users_table .................... 0.60ms DONE
 2024_12_25_000000_add_performance_indexes ......................... 0.56ms FAIL

   Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 1 index monitors_is_enabled_index already exists (Connection: sqlite, SQL: create index "monitors_is_enabled_index" on "monitors" ("is_enabled"))

```